### PR TITLE
Adding moisture level support

### DIFF
--- a/src/core/message/presentation.rs
+++ b/src/core/message/presentation.rs
@@ -69,6 +69,7 @@ impl PresentationType {
             PresentationType::Hum => "multiLevelSensor".to_owned(),
             PresentationType::Lock => "onOffSwitch".to_owned(),
             PresentationType::AirQuality => "multiLevelSensor".to_owned(),
+            PresentationType::Moisture => "multiLevelSensor".to_owned(),
             _ => "".to_owned(),
         }
     }
@@ -84,6 +85,7 @@ impl PresentationType {
             PresentationType::Hum => "Humidity sensor".to_owned(),
             PresentationType::Lock => "Lock device".to_owned(),
             PresentationType::AirQuality => "Air Quality sensor".to_owned(),
+            PresentationType::Moisture => "Moisture sensor".to_owned(),
             _ => "".to_owned(),
         }
     }
@@ -99,6 +101,7 @@ impl PresentationType {
             PresentationType::Hum => vec![SetReqType::Hum],
             PresentationType::Lock => vec![SetReqType::LockStatus],
             PresentationType::AirQuality => vec![SetReqType::Level, SetReqType::UnitPrefix],
+            PresentationType::Moisture => vec![SetReqType::Level, SetReqType::Percentage], // Can I mix them like this?
             _ => Vec::new(),
         }
     }
@@ -159,5 +162,6 @@ mod test {
         assert!(PresentationType::Hum.is_supported());
         assert!(PresentationType::Lock.is_supported());
         assert!(PresentationType::AirQuality.is_supported());
+        assert!(PresentationType::Moisture.is_supported());
     }
 }


### PR DESCRIPTION
Moisture level is a percentage. Used in plant health sensors, for example.

I've added a comment with a question in the code. It's about mixing existing things.

I checked set.rs too, but it seems that I didn't have to add anything there.