### PR TITLE
"type" must be in capital letters

### DIFF
--- a/conf.ini
+++ b/conf.ini
@@ -6,10 +6,11 @@ encoding=utf-8
 type=TCP
 port=0.0.0.0:5003
 ; If you have a device that is acting as the MySensors Gateway 
-; (for example an Arduino you connected via USB) and you want to connect to it via serial port, then uncomment the two lines below and comment out the two lines above.
-;type=Serial
-;port=/dev/cu.tty
-;baud_rate=9600
+; (for example an Arduino you connected via USB) and you want to connect to it via serial port, 
+; then uncomment the three lines below and comment out the two lines above.
+;type=SERIAL
+;port=/dev/ttyUSB0
+;baud_rate=115200
 
 ; This is optional. 
 ; MySController-rs created a Web of Things server, 


### PR DESCRIPTION
Default MySensors baudrate is 115200.
Default FTDI serial gateway (which they recommend) would most likely be ttyUSB0 on a Raspberry Pi.
Plus some cosmetic changes.